### PR TITLE
sbc: fix shellhost install task

### DIFF
--- a/sbc/tasks/install-shellhost-ubuntu.yml
+++ b/sbc/tasks/install-shellhost-ubuntu.yml
@@ -10,7 +10,7 @@
 
  - git:
      repo: https://github.com/practable/relay.git
-     dest: /home/pi/sources/relay
+     dest: /home/ubuntu/sources/relay
      update: yes
 
  - name: shell build


### PR DESCRIPTION
Fixes install issue for shell command on odroid (was going to location for the pi)